### PR TITLE
Fix install script with updated filenames

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,7 +15,7 @@ A development oriented proxy server based off of [[https://devcenter.heroku.com/
 Symlink any application that has a procfile (or a config.ru) into the configuration directory.
 
 #+BEGIN_SRC shell
-$ ln -s <project_path> $HOME/.config/innervate/my-app-name 
+$ ln -s <project_path> /usr/local/etc/innervate/my-app-name
 #+END_SRC
 
 Navigate to your application

--- a/__support__/install.sh
+++ b/__support__/install.sh
@@ -4,7 +4,7 @@ if [ `uname` == "Darwin" ]; then
     go get
     go build
     cp innervate /usr/local/bin/innervate
-    cp __support__/launchd.plist /Library/LaunchDaemons/launchd.plist
-    chmod chown root:wheel /Library/LaunchDaemons/launchd.plist
-    echo "Run `sudo launchctl -w /Library/LaunchDaemons/launchd.plist` or restart to launch Innervate"
+    cp __support__/innervated.plist /Library/LaunchDaemons/innervated.plist
+    chown root:wheel /Library/LaunchDaemons/innervated.plist
+    echo "Run 'sudo launchctl load -w /Library/LaunchDaemons/innervate.plist' or restart to launch Innervate"
 fi


### PR DESCRIPTION
This is mostly an update of the plist file since it changed names https://github.com/hmadison/innervate/commit/a30ca938f45ecfca679422578d4dd5f647c65bd4 with some other minor tweaks as well. The back ticks in the echo command were actually running the command, I guessed that was unintentional, but I'm not sure.

I also noticed the default directory `/usr/local/etc/innervate` doesn't exist and must be created manually. Should that happen automatically somewhere as well?